### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Peter Mitrano <mitranopeter@gmail.com>
 maintainer=Peter Mitrano <mitranopeter@gmail.com>
 sentence="THE go-to Library for well organized Robot Code."
 paragraph="CommanDuino is based on WPILib's Commnad-Based Programming paradigm. Essentially, you define commands, which do actual work, and command groups, which organize commands in series or parallel. This makes for readable, maintainable, modular robot code without duplication or global variables."
-category="Other"
+category=Other
 url=https://github.com/petermitrano/CommanDuino
 architectures=avr


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category "Other" in library CommanDuino is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format